### PR TITLE
JPA 오류 해결

### DIFF
--- a/backend/src/main/java/com/gdsc/coby/domain/Comment.java
+++ b/backend/src/main/java/com/gdsc/coby/domain/Comment.java
@@ -16,7 +16,6 @@ public class Comment {
     private Long id;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name="id")
     private Post post;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/gdsc/coby/domain/GroupTagMap.java
+++ b/backend/src/main/java/com/gdsc/coby/domain/GroupTagMap.java
@@ -13,10 +13,8 @@ public class GroupTagMap {
     private Long id;
 
     @ManyToOne(optional = false)
-    @JoinColumn(name = "id")
     private Group group;
 
     @ManyToOne(optional = false)
-    @JoinColumn(name = "id")
     private Tag tag;
 }

--- a/backend/src/main/java/com/gdsc/coby/domain/Post.java
+++ b/backend/src/main/java/com/gdsc/coby/domain/Post.java
@@ -17,7 +17,6 @@ public class Post {
     private Long id;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name="id")
     private Group group;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/gdsc/coby/domain/RoomTagMap.java
+++ b/backend/src/main/java/com/gdsc/coby/domain/RoomTagMap.java
@@ -13,10 +13,8 @@ public class RoomTagMap {
     private Long id;
 
     @ManyToOne(optional = false)
-    @JoinColumn(name = "id")
     private Room room;
 
     @ManyToOne(optional = false)
-    @JoinColumn(name = "id")
     private Tag tag;
 }

--- a/backend/src/main/java/com/gdsc/coby/domain/User.java
+++ b/backend/src/main/java/com/gdsc/coby/domain/User.java
@@ -16,11 +16,11 @@ public class User {
     private String email;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="id")
     private Group group;
 
     @Column(nullable = false)
     private String name;
+    
     @Column(nullable = false)
     private String password;
 


### PR DESCRIPTION
JoinColumn 어노테이션에서 컬럼명이 중복돼서 오류가 발생했다.
굳이 없어도 된다고 해서 삭제했다.