### PR TITLE
서버 배포

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -42,4 +42,7 @@ src/main/generated
 ### S3 관련 파일 ###
 application-aws.yml
 application-credentials.yml
->>>>>>> origin/main
+
+### SSL ###
+static/.well-known/
+keystore.p12

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -44,5 +44,5 @@ application-aws.yml
 application-credentials.yml
 
 ### SSL ###
-static/.well-known/
+src/main/resources/static
 keystore.p12

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-alpine
+
+COPY build/libs/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/src/main/java/com/gdsc/coby/config/CorsConfig.java
+++ b/backend/src/main/java/com/gdsc/coby/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("http://localhost:3000");
+        config.addAllowedOrigin("https://cobys.netlify.app");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         source.registerCorsConfiguration("/**",config);

--- a/backend/src/main/java/com/gdsc/coby/config/SecurityConfig.java
+++ b/backend/src/main/java/com/gdsc/coby/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 // 조건별로 요청 허용/제한 설정
                 .authorizeHttpRequests()
                 // 회원가입과 로그인은 모두 승인
-                .requestMatchers("/api/signup", "/api/login").permitAll()
+                .requestMatchers("/api/signup", "/api/login", "/.well-known/pki-validation/**").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/configuration/**", "/swagger-resources/**", "/swagger-ui/**", "/webjars/**", "swagger-ui.html", "/api-docs/json").permitAll()
                 .requestMatchers("/api/users/**").hasRole("USER")
                 .anyRequest().authenticated()

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
   data:
     redis:
       port: 6379
-      host: localhost
+      host: redis
 
   profiles:
     include:
@@ -50,3 +50,11 @@ springdoc:
   pre-loading-enabled: true
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
+
+server:
+  ssl:
+    enabled: true
+    key-store: classpath:keystore.p12
+    key-store-password: coby
+    key-store-type: PKCS12
+  port: 8080


### PR DESCRIPTION
- EC2 인스턴스와 도메인 주소 Route53으로 연결
- https 적용하기 위해 ssl인증서 발급
- 인증서를 java keystore로 변환 후 spring boot 프로젝트에 저장
---
- Docker 이미지 생성, docker hub에 push
- EC2에서 pull 후 docker-compose로 redis, 서버 이미지 같이 실행